### PR TITLE
Fix Compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 #![crate_name="termbox"]
 #![crate_type="lib"]
 
-#![feature(core)]
-
 #[macro_use]
 extern crate bitflags;
 extern crate libc;

--- a/src/public.rs
+++ b/src/public.rs
@@ -34,7 +34,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 //
 
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Debug)]
 pub enum Error {
   FailedToOpenTty,
   PipeTrapError,


### PR DESCRIPTION
The build was broken on Rust 1.0, but the fix was only a couple lines.

Confirmed working on `rustc 1.0.0-nightly (2baf34825 2015-04-21) (built 2015-04-21)`

@Daggerbot 